### PR TITLE
Remove fusion-tokens as peer dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "flow-bin": "^0.77.0",
     "fusion-core": "^1.3.1",
     "fusion-react": "^1.1.0",
-    "fusion-tokens": "^1.0.3",
     "nyc": "^12.0.0",
     "prettier": "^1.12.1",
     "react": "^16.3.2",
@@ -50,7 +49,6 @@
   "peerDependencies": {
     "fusion-core": "^1.0.2",
     "fusion-react": "^1.0.2",
-    "fusion-tokens": "^1.0.1"
   },
   "scripts": {
     "clean": "rm -rf dist",


### PR DESCRIPTION
Removes fusion-tokens since this is unused.

@rtsao: You mentioned also removing fusion-react across the board as a peer dep but I'm not sure if that is the right move here. This plugin exports objects created by fusion-react (a provider plugin and a React HOC). 

If we were to make this a regular dependency, that would mean that a Fusion app running a newer version of fusion-react along with this plugin would result in potential incompatible versions, depending on if the interfaces for the provider plugin and the React HOC changed.