### PR TITLE
Release v1.0.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fusion-plugin-universal-events-react",
   "description": "React Provider and HOC for Fusion universal-events",
-  "version": "1.0.4-0",
+  "version": "1.0.4",
   "repository": "fusionjs/fusion-plugin-universal-events-react",
   "keywords": [],
   "license": "MIT",


### PR DESCRIPTION
It looks like `v1.0.3` did not publish correctly due to a naming conflict:

It looks like our publishing job currently clones repositories by checking out the release tag.  [For example](https://buildkite.com/uberopensource/npm-deploy/builds/929#d84d9ef6-ad66-4689-a61f-f7426a4e5062):

`git clone -b v1.0.3 git@github.com:fusionjs/fusion-plugin-universal-events-react.git deploy_repo`

Unfortunately, in this case, a branch exists that is named [`v1.0.3`](https://github.com/fusionjs/fusion-plugin-universal-events-react/tree/v1.0.3) which would be cloned instead of the commit associated with a tag with the same name.

**Solution**

Manually cut the next release, even though our automated release process did not flag it for release.