### PR TITLE
Release v1.0.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fusion-plugin-universal-events-react",
   "description": "React Provider and HOC for Fusion universal-events",
-  "version": "1.0.9-0",
+  "version": "1.0.9",
   "repository": "fusionjs/fusion-plugin-universal-events-react",
   "keywords": [],
   "license": "MIT",


### PR DESCRIPTION
- Bump fusion-plugin-universal-events dependency to latest pre-release ([#180](https://github.com/fusionjs/fusion-plugin-universal-events-react/pull/180))